### PR TITLE
Handle http-host (bind address) in configuration

### DIFF
--- a/src/me/untethr/nostr/conf.clj
+++ b/src/me/untethr/nostr/conf.clj
@@ -7,6 +7,7 @@
 ;; known dependencies: test.config-test/make-test-conf
 (defrecord Conf
   [^String optional-hostname
+   ^String http-host
    ^Long http-port
    ^String sqlite-file
    ^String sqlite-kv-file
@@ -20,6 +21,7 @@
    nip42-auth-enabled?])
 
 (defn pretty* [{:keys [optional-hostname
+                       http-host
                        http-port
                        sqlite-file
                        sqlite-kv-file
@@ -34,6 +36,7 @@
   (str/join
     "\n"
     [(format "hostname: %s" (or optional-hostname "none specified"))
+     (format "bind address: %s" http-host)
      (format "port: %d" http-port)
      (format "database file: %s" sqlite-file)
      (format "database file (k/v store): %s" sqlite-kv-file)
@@ -112,6 +115,7 @@
   (let [from-yaml (yaml/parse-stream reader)]
     (->Conf
       (get-in from-yaml [:hostname])
+      (get-in from-yaml [:http :host])
       (long (get-in from-yaml [:http :port]))
       (get-in from-yaml [:sqlite :file])
       (get-in from-yaml [:sqlite :file-kv])

--- a/test/test/app_test.clj
+++ b/test/test/app_test.clj
@@ -23,7 +23,7 @@
   ([supported-kinds-vec unserved-kinds-vec max-content-length]
    (make-test-conf supported-kinds-vec unserved-kinds-vec max-content-length nil))
   ([supported-kinds-vec unserved-kinds-vec max-content-length max-created-at-delta]
-   (conf/->Conf nil 1234 "nx.db" "nx-kb.db"
+   (conf/->Conf nil "127.0.0.1" 1234 "nx.db" "nx-kb.db"
      (some->> supported-kinds-vec (hash-map :supported-kinds) conf/parse-supported-kinds*)
      (some->> unserved-kinds-vec (hash-map :unserved-kinds) conf/parse-unserved-kinds*)
      max-content-length max-created-at-delta nil nil nil nil)))

--- a/test/test/conf_test.clj
+++ b/test/test/conf_test.clj
@@ -20,12 +20,14 @@
   (with-open [reader (StringReader.
                        (str
                          "http:\n"
+                         "  host: 127.0.0.1\n"
                          "  port: 1234\n"
                          "sqlite:\n"
                          "  file: \"nx.db\"\n"))]
     (let [parsed (conf/parse-conf reader)]
       (is (= "nx.db" (:sqlite-file parsed)))
       (is (= 1234 (:http-port parsed)))
+      (is (= "127.0.0.1" (:http-host parsed)))
       (is (nil? (:optional-hostname parsed)))
       (is (nil? (:optional-supported-kinds-range-set parsed)))))
 


### PR DESCRIPTION
This configuration setting was simply ignored until now, although it is documented in the default configuration file.